### PR TITLE
🏷️ refactor: add hash key and range key typing to methods

### DIFF
--- a/dyntastic/main.py
+++ b/dyntastic/main.py
@@ -27,6 +27,8 @@ from .transact import current_transaction_writer
 __version__ = _metadata.version("dyntastic")
 
 _T = TypeVar("_T", bound="Dyntastic")
+_THash = TypeVar("_THash")
+_TRange = TypeVar("_TRange")
 
 
 class _TableMetadata:
@@ -75,7 +77,7 @@ class Index:
         self.index_name = index_name
 
 
-class Dyntastic(_TableMetadata, pydantic_compat.BaseModel):
+class Dyntastic(_TableMetadata, pydantic_compat.BaseModel, Generic[_THash, _TRange]):
     _dyntastic_unrefreshed: bool = PrivateAttr(default=False)
     _dyntastic_missing_attributes_from_index: bool = PrivateAttr(default=False)
 
@@ -107,12 +109,12 @@ class Dyntastic(_TableMetadata, pydantic_compat.BaseModel):
     def _serialize_key(
         cls,
         method: str,
-        hash_key: Any,
-        range_key: Any,
+        hash_key: _THash,
+        range_key: _TRange,
         hash_key_type: Optional[Type] = None,
         range_key_type: Optional[Type] = None,
     ) -> dict:
-        key = {cls.__hash_key__: hash_key}
+        key: dict[str, Union[_THash, _TRange]] = {cls.__hash_key__: hash_key}
         if cls.__range_key__:
             key[cls.__range_key__] = range_key
 
@@ -156,7 +158,13 @@ class Dyntastic(_TableMetadata, pydantic_compat.BaseModel):
         return attr.serialize(key)
 
     @classmethod
-    def get(cls: Type[_T], hash_key, range_key=None, *, consistent_read: bool = False) -> _T:
+    def get(
+        cls: Type[_T],
+        hash_key: _THash,
+        range_key: Optional[_TRange] = None,
+        *,
+        consistent_read: bool = False,
+    ) -> _T:
         serialized_key = cls._serialize_key("get", hash_key, range_key)
         response = cls._dynamodb_table().get_item(Key=serialized_key, ConsistentRead=consistent_read)
         data = response.get("Item")
@@ -166,7 +174,13 @@ class Dyntastic(_TableMetadata, pydantic_compat.BaseModel):
             raise DoesNotExist
 
     @classmethod
-    def safe_get(cls: Type[_T], hash_key, range_key=None, *, consistent_read: bool = False) -> Optional[_T]:
+    def safe_get(
+        cls: Type[_T],
+        hash_key: _THash,
+        range_key: Optional[_TRange] = None,
+        *,
+        consistent_read: bool = False,
+    ) -> Optional[_T]:
         try:
             return cls.get(hash_key, range_key=range_key, consistent_read=consistent_read)
         except DoesNotExist:
@@ -175,7 +189,7 @@ class Dyntastic(_TableMetadata, pydantic_compat.BaseModel):
     @classmethod
     def batch_get(
         cls: Type[_T],
-        keys: Union[List[Any], List[Tuple[Any, Any]]],
+        keys: Union[List[_THash], List[Tuple[_THash, _TRange]]],
         consistent_read: bool = False,
     ) -> List[_T]:
         hash_key_type = pydantic_compat.field_type(cls, cls.__hash_key__)
@@ -189,7 +203,7 @@ class Dyntastic(_TableMetadata, pydantic_compat.BaseModel):
                 raise ValueError(
                     f"Must provide (hash_key, range_key) tuples as `keys` to {cls.__name__}.batch_get(), got {key}"
                 )
-            hash_key, range_key = key if cls.__range_key__ else (key, None)
+            hash_key, range_key = key if cls.__range_key__ and isinstance(key, tuple) else (key, None)
             serialized_key = cls._serialize_key("batch_get", hash_key, range_key, hash_key_type, range_key_type)
             serialized_keys.append(serialized_key)
 
@@ -209,7 +223,7 @@ class Dyntastic(_TableMetadata, pydantic_compat.BaseModel):
     @classmethod
     def query(
         cls: Type[_T],
-        hash_key,
+        hash_key: _THash,
         *,
         consistent_read: bool = False,
         range_key_condition=None,
@@ -242,7 +256,7 @@ class Dyntastic(_TableMetadata, pydantic_compat.BaseModel):
     @classmethod
     def query_page(
         cls: Type[_T],
-        hash_key: Union[str, ConditionBase],
+        hash_key: Union[str, ConditionBase, _THash],
         *,
         consistent_read: bool = False,
         range_key_condition: Optional[ConditionBase] = None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,13 @@ class MyIntObject(Dyntastic):
     id: int
 
 
+class MyTypedIntObject(Dyntastic[int]):
+    __table_name__ = "my_int_object"
+    __hash_key__ = "id"
+
+    id: int
+
+
 # No hash key defined because this inherits from MyObject
 # This class also covers testing __table_name__ being a function instead of a string
 class MyRangeObject(MyObject):
@@ -279,6 +286,15 @@ def populated_int_model(request):
         MyIntObject(id=i).save()
     yield MyIntObject
     MyIntObject._clear_boto3_state()
+
+
+@pytest.fixture
+def populated_typed_int_model(request):
+    MyTypedIntObject.create_table()
+    for i in range(10):
+        MyTypedIntObject(id=i).save()
+    yield MyTypedIntObject
+    MyTypedIntObject._clear_boto3_state()
 
 
 @pytest.fixture

--- a/tests/test_batch_get.py
+++ b/tests/test_batch_get.py
@@ -3,6 +3,7 @@ import pytest
 from .conftest import (
     MyAliasObject,
     MyIntObject,
+    MyTypedIntObject,
     MyObject,
     MyRangeObject,
     alias_query_data,
@@ -33,6 +34,14 @@ def test_get_by_alias_hash_key(populated_alias_model):
 def test_get_by_int_hash_key(populated_int_model):
     assert populated_int_model.batch_get([1, 2, 3]) == [MyIntObject(id=1), MyIntObject(id=2), MyIntObject(id=3)]
     assert populated_int_model.batch_get([1, 2, 3, 1000]) == [MyIntObject(id=1), MyIntObject(id=2), MyIntObject(id=3)]
+
+
+def test_get_by_typed_int_hash_key(populated_typed_int_model):
+    assert populated_typed_int_model.batch_get([1, 2, 3, "foo"]) == [
+        MyTypedIntObject(id=1),
+        MyTypedIntObject(id=2),
+        MyTypedIntObject(id=3),
+    ]
 
 
 def test_get_by_hash_key_and_range_key(populated_range_model):

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -2,7 +2,7 @@ import pytest
 
 from dyntastic import DoesNotExist
 
-from .conftest import MyIntObject, MyObject, MyRangeObject
+from .conftest import MyIntObject, MyObject, MyRangeObject, MyTypedIntObject
 
 
 def test_get_by_hash_key(hash_item):
@@ -15,6 +15,12 @@ def test_get_by_int_hash_key(populated_int_model):
     retrieved = MyIntObject.get(1)
     safe_retrieved = MyIntObject.safe_get(1)
     assert retrieved == safe_retrieved == MyIntObject(id=1)
+
+
+def test_get_by_typed_int_hash_key(populated_typed_int_model):
+    retrieved = MyTypedIntObject.get(1)
+    safe_retrieved = MyTypedIntObject.safe_get(1)
+    assert retrieved == safe_retrieved == MyTypedIntObject(id=1)
 
 
 def test_get_with_range_key(range_item):


### PR DESCRIPTION
This adds in generic support so that we can get proper typing errors from pyright.